### PR TITLE
[codex] HeaderFeature Swift Testing 추가

### DIFF
--- a/Feature/CarveFeature/Tests/HeaderFeatureTesting.swift
+++ b/Feature/CarveFeature/Tests/HeaderFeatureTesting.swift
@@ -1,0 +1,56 @@
+//
+//  HeaderFeatureTesting.swift
+//  FeatureCarveTest
+//
+//  Created by Codex on 4/2/26.
+//
+
+@testable import CarveFeature
+import Testing
+
+struct HeaderFeatureTesting {
+    @Test("헤더 토글로 숨길 때 높이만큼 올리고 추적 상태를 초기화한다")
+    func toggleVisibilityHidesHeaderAndResetsTracking() async {
+        var state = HeaderFeature.State.initialState
+        state.headerHeight = 72
+        state.headerOffset = -18
+        state.lastHeaderOffset = -18
+        state.direction = .up
+        state.shiftOffset = -24
+
+        _ = HeaderFeature().reduce(into: &state, action: .toggleVisibility)
+
+        #expect(state.isHidden)
+        #expect(state.headerOffset == -72)
+        #expect(state.direction == .none)
+        #expect(state.shiftOffset == 0)
+        #expect(state.lastHeaderOffset == -72)
+    }
+
+    @Test("위로 스크롤을 계속하면 헤더 오프셋이 높이를 넘지 않게 고정된다")
+    func headerAnimationClampsOffsetWhileScrollingUp() async {
+        var state = HeaderFeature.State.initialState
+        state.headerHeight = 72
+        state.direction = .up
+        state.shiftOffset = -12
+
+        _ = HeaderFeature().reduce(into: &state, action: .headerAnimation(-12, -120))
+
+        #expect(state.headerOffset == -72)
+    }
+
+    @Test("탭으로 숨긴 뒤 아래로 스크롤하면 숨김 상태를 해제하고 아래 방향으로 전환한다")
+    func headerAnimationClearsHiddenStateOnScrollDown() async {
+        var state = HeaderFeature.State.initialState
+        state.headerHeight = 72
+        state.headerOffset = -72
+        state.isHidden = true
+
+        _ = HeaderFeature().reduce(into: &state, action: .headerAnimation(-10, 20))
+
+        #expect(!state.isHidden)
+        #expect(state.direction == .down)
+        #expect(state.shiftOffset == 20)
+        #expect(state.lastHeaderOffset == -72)
+    }
+}


### PR DESCRIPTION
## 변경 내용
- `Feature/CarveFeature` 모듈에 `HeaderFeatureTesting` Swift Testing 파일을 추가했습니다.
- 헤더 토글 숨김 시 오프셋과 추적 상태 초기화 동작을 검증했습니다.
- 위로 스크롤할 때 헤더 오프셋이 높이를 넘지 않도록 고정되는 동작을 검증했습니다.
- 탭으로 숨긴 뒤 아래로 스크롤할 때 숨김 상태가 해제되고 방향이 아래로 전환되는 동작을 검증했습니다.

## 이유
- `HeaderFeature`의 핵심 상태 전환은 UI 렌더링 없이도 결정적으로 검증할 수 있는데, 기존에는 초기화 확인 테스트만 있어 회귀를 막기 어려웠습니다.
- 헤더 표시/숨김 로직의 경계 동작을 작은 단위 테스트로 고정해 스크롤 관련 회귀를 빠르게 감지하려는 목적입니다.

## 검증
- `tuist generate`
- `xcodebuild test -workspace Carve.xcworkspace -scheme CarveFeatureTest -destination 'id=54940DF2-F805-4BFA-942D-04B910E9754A'`

## 남은 위험
- 이번 PR은 `HeaderFeature`의 순수 상태 전환만 다루며, 실제 스크롤 이벤트 연결이나 애니메이션 체감은 포함하지 않습니다.
- 워크트리에 남아 있는 다른 모듈 변경은 이번 PR 범위에 포함하지 않았습니다.