### PR TITLE
[테스트] Domain BibleVerse 파싱 경계 케이스 Swift Testing 추가

### DIFF
--- a/Domain/Domain/Tests/BibleVerseParsingTesting.swift
+++ b/Domain/Domain/Tests/BibleVerseParsingTesting.swift
@@ -71,4 +71,42 @@ struct BibleVerseParsingTesting {
         #expect(verse.verse == 16)
         #expect(verse.sentenceScript == "하나님이 세상을 이처럼 사랑하사")
     }
+
+    @Test("장절만 있고 본문이 없으면 빈 문자열로 정리하고 기본 소제목을 유지한다")
+    func keepsProvidedChapterTitleWhenReferenceHasNoBody() {
+        let verse = BibleVerse(
+            title: BibleChapter(title: .john, chapter: 3),
+            chapterTitle: "기본 소제목",
+            sentence: "3:16"
+        )
+
+        #expect(verse.chapterTitle == "기본 소제목")
+        #expect(verse.verse == 16)
+        #expect(verse.sentenceScript.isEmpty)
+    }
+
+    @Test("소제목과 장절만 있으면 본문은 비우고 소제목과 절 번호는 유지한다")
+    func parsesTitleAndReferenceWithoutBody() {
+        let verse = BibleVerse(
+            title: BibleChapter(title: .john, chapter: 3),
+            sentence: "<하나님의 사랑> 3:16"
+        )
+
+        #expect(verse.chapterTitle == "하나님의 사랑")
+        #expect(verse.verse == 16)
+        #expect(verse.sentenceScript.isEmpty)
+    }
+
+    @Test("장절과 소제목이 모두 없으면 기본 소제목과 본문을 그대로 유지한다")
+    func keepsProvidedChapterTitleAndBodyWhenReferenceIsMissing() {
+        let verse = BibleVerse(
+            title: BibleChapter(title: .john, chapter: 3),
+            chapterTitle: "기본 소제목",
+            sentence: "하나님이 세상을 이처럼 사랑하사"
+        )
+
+        #expect(verse.chapterTitle == "기본 소제목")
+        #expect(verse.verse == 0)
+        #expect(verse.sentenceScript == "하나님이 세상을 이처럼 사랑하사")
+    }
 }


### PR DESCRIPTION
## 요약
- `Domain` 모듈의 `BibleVerse` 파싱 로직에 대한 Swift Testing 경계 케이스 3개를 추가했습니다.
- 장절만 있는 입력, 소제목과 장절만 있는 입력, 장절과 소제목이 모두 없는 입력에서 상태가 안정적으로 유지되는지 검증합니다.

## 선택한 모듈
- `Domain`

## 테스트한 동작
- 장절만 있고 본문이 없을 때 기본 소제목을 유지하고 본문을 빈 문자열로 정리하는지
- 소제목과 장절만 있고 본문이 없을 때 소제목과 절 번호를 올바르게 파싱하는지
- 장절과 소제목이 모두 없을 때 기본 소제목과 본문을 그대로 유지하는지

## 변경 파일
- `Domain/Domain/Tests/BibleVerseParsingTesting.swift`

## 검증 단계
- `xcodebuild test -workspace /Users/leetaek/Documents/Dev/Carve/Carve.xcworkspace -scheme DomainTest -destination 'platform=iOS Simulator,id=D3698D7B-337F-40EE-9C8B-1ABFDE87DCF4' -derivedDataPath /tmp/CarveDerived -only-testing:DomainTest/BibleVerseParsingTesting`

## 남은 위험 요소
- 현재 검증은 `BibleVerseParsingTesting` 스위트에 한정되어 있으며, 다른 `DomainTest` 스위트 전체 재실행은 포함하지 않았습니다.
- 실제 파싱 로직 변경은 없으므로, 이번 PR은 기존 동작을 문서화하고 회귀를 막는 테스트 보강 성격입니다.