### PR TITLE
test: BibleVerse 파싱 경계값 Swift Testing 추가

### DIFF
--- a/Domain/Domain/Tests/BibleVerseParsingTesting.swift
+++ b/Domain/Domain/Tests/BibleVerseParsingTesting.swift
@@ -71,4 +71,40 @@ struct BibleVerseParsingTesting {
         #expect(verse.verse == 16)
         #expect(verse.sentenceScript == "하나님이 세상을 이처럼 사랑하사")
     }
+
+    @Test("소제목이 전혀 없으면 chapterTitle은 nil로 유지한다")
+    func keepsChapterTitleNilWhenNoDefaultOrEmbeddedTitleExists() {
+        let verse = BibleVerse(
+            title: BibleChapter(title: .john, chapter: 3),
+            sentence: "3:16 하나님이 세상을 이처럼 사랑하사"
+        )
+
+        #expect(verse.chapterTitle == nil)
+        #expect(verse.verse == 16)
+        #expect(verse.sentenceScript == "하나님이 세상을 이처럼 사랑하사")
+    }
+
+    @Test("장절과 소제목을 제거한 뒤 남은 본문의 앞뒤 공백과 줄바꿈을 정리한다")
+    func trimsWhitespaceAfterRemovingReferenceAndTitle() {
+        let verse = BibleVerse(
+            title: BibleChapter(title: .john, chapter: 3),
+            sentence: "\n  <하나님의 사랑> 3:16   하나님이 세상을 이처럼 사랑하사  \n"
+        )
+
+        #expect(verse.chapterTitle == "하나님의 사랑")
+        #expect(verse.verse == 16)
+        #expect(verse.sentenceScript == "하나님이 세상을 이처럼 사랑하사")
+    }
+
+    @Test("소제목과 장절만 있으면 본문은 빈 문자열로 남긴다")
+    func leavesSentenceEmptyWhenOnlyTitleAndReferenceExist() {
+        let verse = BibleVerse(
+            title: BibleChapter(title: .john, chapter: 3),
+            sentence: "<하나님의 사랑> 3:16"
+        )
+
+        #expect(verse.chapterTitle == "하나님의 사랑")
+        #expect(verse.verse == 16)
+        #expect(verse.sentenceScript.isEmpty)
+    }
 }


### PR DESCRIPTION
## 요약
- `Domain` 모듈의 `BibleVerse` 파싱 로직에 대한 Swift Testing 경계값 테스트 3개를 추가했습니다.
- 소제목 부재 시 `chapterTitle`이 `nil`로 유지되는지, 장절/소제목 제거 뒤 공백 정리가 되는지, 본문이 없는 입력을 안정적으로 처리하는지 검증했습니다.

## 선택한 모듈
- `Domain`

## 테스트한 동작
- 소제목이 없는 입력에서 `chapterTitle`이 `nil`로 유지되는지
- 장절/소제목 제거 후 남은 본문의 앞뒤 공백과 줄바꿈이 정리되는지
- 소제목과 장절만 있는 입력에서 본문이 빈 문자열로 남는지

## 변경 파일
- `Domain/Domain/Tests/BibleVerseParsingTesting.swift`

## 검증 단계
- `xcodebuild test -workspace Carve.xcworkspace -scheme DomainTest -destination 'platform=iOS Simulator,id=54940DF2-F805-4BFA-942D-04B910E9754A'`

## 남은 위험 요소
- `BibleVerse` 파싱은 단일 소제목/단일 장절 패턴을 기준으로 검증했습니다.
- 다중 소제목 또는 비정형 본문 형식에 대한 스펙은 이번 범위에 포함하지 않았습니다.