### PR TITLE
Domain 성경 파싱 경계 테스트 추가

### DIFF
--- a/Domain/Domain/Tests/BibleChapterAndVerseTesting.swift
+++ b/Domain/Domain/Tests/BibleChapterAndVerseTesting.swift
@@ -9,26 +9,26 @@
 import Testing
 
 struct BibleChapterAndVerseTesting {
-    @Test
+    @Test("창세기에서 이전으로 이동하면 요한계시록으로 순환한다")
     func beforeWrapsFromGenesisToRevelation() {
         // 첫 권에서 이전으로 이동할 때 마지막 권으로 순환해야 한다.
         #expect(BibleTitle.genesis.before() == .revelation)
     }
 
-    @Test
+    @Test("요한계시록에서 다음으로 이동하면 창세기로 순환한다")
     func nextWrapsFromRevelationToGenesis() {
         // 마지막 권은 배열 범위를 벗어나지 않고 첫 권으로 순환해야 한다.
         #expect(BibleTitle.revelation.next() == .genesis)
     }
 
-    @Test
+    @Test("구약과 신약의 경계는 말라기와 마태복음으로 판단한다")
     func isOldTestamentUsesCanonBoundary() {
         // 말라기까지는 구약, 마태복음부터는 신약으로 구분돼야 한다.
         #expect(BibleTitle.malachi.isOldtestment)
         #expect(!BibleTitle.matthew.isOldtestment)
     }
 
-    @Test
+    @Test("한 줄 문자열에서 소제목, 절 번호, 본문을 분리한다")
     func verseInitParsesChapterTitleVerseAndSentence() {
         // "<소제목> 장:절 본문" 형식이 한 줄에 함께 들어와도 각 필드가 분리돼야 한다.
         let verse = BibleVerse(
@@ -41,7 +41,7 @@ struct BibleChapterAndVerseTesting {
         #expect(verse.sentenceScript == "하나님이 세상을 이처럼 사랑하사")
     }
 
-    @Test
+    @Test("본문 리소스 조회는 요청한 장에 해당하는 절만 반환한다")
     func bibleTextClientFetchesOnlyRequestedChapterVerses() throws {
         let chapter = BibleChapter(title: .genesis, chapter: 1)
 
@@ -54,13 +54,13 @@ struct BibleChapterAndVerseTesting {
         #expect(verses.contains { $0.verse == 1 })
     }
 
-    @Test
+    @Test("알 수 없는 파일명 조각은 기본값으로 창세기를 반환한다")
     func getTitleFallsBackToGenesisWhenNoMatchExists() {
         // 파일명 규칙이 깨진 입력이 들어와도 기본값은 안정적으로 창세기여야 한다.
         #expect(BibleTitle.getTitle("NotExistingBook.txt") == .genesis)
     }
 
-    @Test
+    @Test("파일명 일부 조각만으로도 해당 책을 찾는다")
     func getTitleMatchesEmbeddedFilenameFragment() {
         // 리소스 경로 일부만 들어와도 해당 책을 안정적으로 찾아야 한다.
         #expect(BibleTitle.getTitle("2-04John") == .john)
@@ -86,5 +86,27 @@ struct BibleChapterAndVerseTesting {
         #expect(BibleTitle.getTitle("2-23John1") == .john1)
         #expect(BibleTitle.getTitle("2-24John2") == .john2)
         #expect(BibleTitle.getTitle("2-25John3") == .john3)
+    }
+
+    @Test("말라기 다음은 마태복음으로 이어져 정경 경계를 넘는다")
+    func nextCrossesFromOldToNewTestament() {
+        #expect(BibleTitle.malachi.next() == .matthew)
+    }
+
+    @Test("마태복음 이전은 말라기로 돌아가 정경 경계를 넘는다")
+    func beforeCrossesFromNewToOldTestament() {
+        #expect(BibleTitle.matthew.before() == .malachi)
+    }
+
+    @Test("장절과 소제목만 있는 줄은 빈 본문으로 정리한다")
+    func verseInitKeepsEmptyBodyWhenOnlyMetadataExists() {
+        let verse = BibleVerse(
+            title: BibleChapter(title: .john, chapter: 3),
+            sentence: "<하나님의 사랑> 3:16"
+        )
+
+        #expect(verse.chapterTitle == "하나님의 사랑")
+        #expect(verse.verse == 16)
+        #expect(verse.sentenceScript.isEmpty)
     }
 }


### PR DESCRIPTION
## 변경 내용
- `Domain` 모듈의 [`/Users/leetaek/Documents/Area/Carve/Carve/Domain/Domain/Tests/BibleChapterAndVerseTesting.swift`](/Users/leetaek/Documents/Area/Carve/Carve/Domain/Domain/Tests/BibleChapterAndVerseTesting.swift) 에 Swift Testing 케이스를 추가했습니다.
- 기존 `@Test` 일부에 한글 설명을 보강해 테스트 의도를 더 읽기 쉽게 정리했습니다.

## 테스트한 동작
- 구약 마지막 권과 신약 첫 권 사이의 `next()`/`before()` 경계 이동
- 장절과 소제목만 있는 문장을 `BibleVerse`가 빈 본문으로 정리하는 파싱 경계값
- 기존 대표 장 수, 한글 제목, 파일명 매핑, 본문 파싱 동작 회귀 확인

## 검증
- `xcodebuild test -project Domain/Domain/Domain.xcodeproj -scheme DomainTest -destination 'platform=iOS Simulator,id=54940DF2-F805-4BFA-942D-04B910E9754A' -only-testing:DomainTest/BibleChapterAndVerseTesting`
  - 단일 모듈 프로젝트로는 의존성 모듈을 찾지 못해 실패
- `tuist generate`
- `xcodebuild test -workspace Carve.xcworkspace -scheme DomainTest -destination 'platform=iOS Simulator,id=54940DF2-F805-4BFA-942D-04B910E9754A' -only-testing:DomainTest/BibleChapterAndVerseTesting`
  - 첫 iPad simulator에서 `xctest` 부트스트랩 segfault로 실패
- `xcodebuild test -workspace Carve.xcworkspace -scheme DomainTest -destination 'platform=iOS Simulator,id=E3E81840-2311-43FB-A515-1D772D1B73B9' -only-testing:DomainTest/BibleChapterAndVerseTesting`
  - 통과

## 남은 위험
- 동일 테스트가 특정 iPad simulator(`iPad Pro 13-inch (M4)`)에서는 환경성 `xctest` 크래시로 한 번 실패했습니다.
- 테스트 본문 자체는 다른 iPad simulator에서 통과했지만, CI/로컬 표준 시뮬레이터가 고정돼 있다면 동일 환경 이슈 재확인이 필요합니다.
