### PR TITLE
[codex] Domain 책 제목 파싱 테스트 보강

### DIFF
--- a/Domain/Domain/Tests/BibleChapterAndVerseTesting.swift
+++ b/Domain/Domain/Tests/BibleChapterAndVerseTesting.swift
@@ -66,6 +66,12 @@ struct BibleChapterAndVerseTesting {
         #expect(BibleTitle.getTitle("2-04John") == .john)
     }
 
+    @Test("정확한 리소스 파일명도 해당 책으로 직접 매핑한다")
+    func getTitleMatchesExactResourceFilename() {
+        #expect(BibleTitle.getTitle("1-01Genesis.txt") == .genesis)
+        #expect(BibleTitle.getTitle("2-18Philemon.txt") == .philemon)
+    }
+
     @Test("대표 책의 마지막 장 수를 정경 기준으로 반환한다")
     func lastChapterReturnsCanonicalCountsForRepresentativeBooks() {
         #expect(BibleTitle.genesis.lastChapter == 50)
@@ -86,5 +92,19 @@ struct BibleChapterAndVerseTesting {
         #expect(BibleTitle.getTitle("2-23John1") == .john1)
         #expect(BibleTitle.getTitle("2-24John2") == .john2)
         #expect(BibleTitle.getTitle("2-25John3") == .john3)
+    }
+
+    @Test("번호가 붙은 구약 역사서도 각 권을 구분해 매핑한다")
+    func getTitleDistinguishesNumberedSamuelBooks() {
+        #expect(BibleTitle.getTitle("1-09Samuel1") == .samuel1)
+        #expect(BibleTitle.getTitle("1-10Samuel2") == .samuel2)
+    }
+
+    @Test("번호가 붙은 서신서도 각 권을 구분해 한글 제목을 반환한다")
+    func koreanTitleReturnsLocalizedNameForNumberedEpistles() {
+        #expect(BibleTitle.thessalonians1.koreanTitle() == "데살로니가전서")
+        #expect(BibleTitle.thessalonians2.koreanTitle() == "데살로니가후서")
+        #expect(BibleTitle.peter1.koreanTitle() == "베드로전서")
+        #expect(BibleTitle.peter2.koreanTitle() == "베드로후서")
     }
 }


### PR DESCRIPTION
## 변경 내용
- `Domain` 모듈의 `BibleChapterAndVerseTesting`에 `BibleTitle` 매핑/한글 제목 관련 Swift Testing 테스트를 3건 추가했습니다.
- 정확한 리소스 파일명 매핑, 번호가 붙은 사무엘서 매핑, 번호가 붙은 서신서 한글 제목 반환을 검증합니다.

## 변경 이유
- 기존 테스트가 일부 대표 케이스만 다루고 있어 번호가 붙은 책 이름과 정확한 파일명 입력에 대한 회귀를 막기 어려웠습니다.
- 결정적인 도메인 로직 범위에서 작은 테스트 보강으로 파싱 안정성을 높였습니다.

## 영향 범위
- 프로덕션 코드 변경은 없고 `Domain` 테스트만 확장했습니다.
- 성경 책 제목/파일명 파싱 로직의 회귀 감지 범위가 넓어집니다.

## 검증
- `tuist generate`
- `xcodebuild test -workspace Carve.xcworkspace -scheme DomainTest -destination 'id=54940DF2-F805-4BFA-942D-04B910E9754A' -only-testing:DomainTest/BibleChapterAndVerseTesting`

## 남은 위험
- `BibleTitle.getTitle(_:)`는 여전히 `contains` 기반의 단순 매핑이라, 향후 더 복잡한 파일명 규칙이 들어오면 추가 보강이 필요할 수 있습니다.
