### PR TITLE
Domain BibleVerse 파싱 테스트 보강

### DIFF
--- a/Domain/Domain/Tests/BibleChapterAndVerseTesting.swift
+++ b/Domain/Domain/Tests/BibleChapterAndVerseTesting.swift
@@ -101,6 +101,7 @@ struct BibleChapterAndVerseTesting {
         #expect(BibleTitle.thessalonians2.koreanTitle() == "데살로니가후서")
         #expect(BibleTitle.peter1.koreanTitle() == "베드로전서")
         #expect(BibleTitle.peter2.koreanTitle() == "베드로후서")
+    }
 
     @Test("말라기 다음 책은 신약의 첫 권인 마태복음으로 이어진다")
     func nextCrossesOldAndNewTestamentBoundary() {

--- a/Domain/Domain/Tests/BibleVerseParsingTesting.swift
+++ b/Domain/Domain/Tests/BibleVerseParsingTesting.swift
@@ -106,7 +106,7 @@ struct BibleVerseParsingTesting {
 
         #expect(verse.chapterTitle == "하나님의 사랑")
         #expect(verse.verse == 16)
-        #expect(verse.sentenceScript == "4:5도 함께 읽습니다")
+        #expect(verse.sentenceScript.isEmpty)
     }
 
     @Test("줄바꿈으로 나뉜 소제목과 장절도 파싱한 뒤 본문 줄바꿈은 유지한다")
@@ -119,7 +119,18 @@ struct BibleVerseParsingTesting {
         #expect(verse.chapterTitle == "하나님의 사랑")
         #expect(verse.verse == 16)
         #expect(verse.sentenceScript == "하나님이 세상을\n이처럼 사랑하사")
-        #expect(verse.sentenceScript.isEmpty)
+    }
+
+    @Test("소제목과 장절을 제거한 뒤 본문 양끝 공백과 개행을 정리한다")
+    func trimsWhitespaceAndNewlinesAroundRemainingSentence() {
+        let verse = BibleVerse(
+            title: BibleChapter(title: .john, chapter: 3),
+            sentence: "\n  <하나님의 사랑> 3:16 하나님이 세상을 이처럼 사랑하사  \n"
+        )
+
+        #expect(verse.chapterTitle == "하나님의 사랑")
+        #expect(verse.verse == 16)
+        #expect(verse.sentenceScript == "하나님이 세상을 이처럼 사랑하사")
     }
 
     @Test("장절과 소제목이 모두 없으면 기본 소제목과 본문을 그대로 유지한다")


### PR DESCRIPTION
## 요약
- `Domain` 모듈의 `BibleVerse` 원시 문장 파싱 Swift Testing 커버리지를 보강했습니다.
- 소제목과 장절만 있는 입력의 본문 기대값을 실제 파싱 동작에 맞게 빈 문자열로 정리했습니다.
- 소제목/장절 제거 후 남은 본문의 양끝 공백과 개행을 정리하는 동작을 새 테스트로 추가했습니다.
- `DomainTest` 컴파일을 막던 기존 테스트 파일의 누락된 닫는 중괄호를 보정했습니다.

## 선택한 모듈
- `Domain`

## 테스트한 동작
- 소제목과 장절만 있는 문장은 소제목과 절 번호를 유지하고 본문을 비웁니다.
- 줄바꿈이 포함된 본문은 파싱 후 내부 줄바꿈을 유지합니다.
- 소제목과 장절을 제거한 뒤 남은 본문의 양끝 공백과 개행을 정리합니다.

## 변경 파일
- `Domain/Domain/Tests/BibleVerseParsingTesting.swift`
- `Domain/Domain/Tests/BibleChapterAndVerseTesting.swift`

## 검증
- `xcodebuild -list -workspace Carve.xcworkspace`
- `xcodebuild test -workspace Carve.xcworkspace -scheme DomainTest -destination 'platform=iOS Simulator,name=iPad (A16),OS=26.2' -only-testing:DomainTest/BibleVerseParsingTesting`

## 남은 위험 요소
- `iPad Pro 13-inch (M4), OS=26.0` destination에서는 테스트 러너가 부트스트랩 중 조기 종료했습니다. 동일 범위는 `iPad (A16), OS=26.2`에서 통과했습니다.
- SwiftLint 기존 warning 9건이 출력됐지만 serious violation은 없었습니다.
