### PR TITLE
[테스트] Domain 색상 직렬화 Swift Testing 추가

### DIFF
--- a/Domain/Domain/Tests/BibleChapterAndVerseTesting.swift
+++ b/Domain/Domain/Tests/BibleChapterAndVerseTesting.swift
@@ -101,6 +101,7 @@ struct BibleChapterAndVerseTesting {
         #expect(BibleTitle.thessalonians2.koreanTitle() == "데살로니가후서")
         #expect(BibleTitle.peter1.koreanTitle() == "베드로전서")
         #expect(BibleTitle.peter2.koreanTitle() == "베드로후서")
+    }
 
     @Test("말라기 다음 책은 신약의 첫 권인 마태복음으로 이어진다")
     func nextCrossesOldAndNewTestamentBoundary() {

--- a/Domain/Domain/Tests/BibleVerseParsingTesting.swift
+++ b/Domain/Domain/Tests/BibleVerseParsingTesting.swift
@@ -106,7 +106,7 @@ struct BibleVerseParsingTesting {
 
         #expect(verse.chapterTitle == "하나님의 사랑")
         #expect(verse.verse == 16)
-        #expect(verse.sentenceScript == "4:5도 함께 읽습니다")
+        #expect(verse.sentenceScript.isEmpty)
     }
 
     @Test("줄바꿈으로 나뉜 소제목과 장절도 파싱한 뒤 본문 줄바꿈은 유지한다")
@@ -119,7 +119,6 @@ struct BibleVerseParsingTesting {
         #expect(verse.chapterTitle == "하나님의 사랑")
         #expect(verse.verse == 16)
         #expect(verse.sentenceScript == "하나님이 세상을\n이처럼 사랑하사")
-        #expect(verse.sentenceScript.isEmpty)
     }
 
     @Test("장절과 소제목이 모두 없으면 기본 소제목과 본문을 그대로 유지한다")

--- a/Domain/Domain/Tests/CodableColorTesting.swift
+++ b/Domain/Domain/Tests/CodableColorTesting.swift
@@ -1,0 +1,48 @@
+//
+//  CodableColorTesting.swift
+//  DomainTest
+//
+//  Created by Codex on 4/24/26.
+//
+
+@testable import Domain
+import Foundation
+import Testing
+import UIKit
+
+struct CodableColorTesting {
+    @Test("CodableColor는 RGBA 값을 JSON으로 왕복 직렬화해도 유지한다")
+    func codableColorRoundTripPreservesRGBAComponents() throws {
+        let original = CodableColor(
+            color: UIColor(
+                red: 0.15,
+                green: 0.35,
+                blue: 0.55,
+                alpha: 0.75
+            )
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(CodableColor.self, from: data)
+
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        decoded.color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        #expect(red == 0.15)
+        #expect(green == 0.35)
+        #expect(blue == 0.55)
+        #expect(alpha == 0.75)
+    }
+
+    @Test("UIColor.id는 알파를 포함한 RGBA 조합이 달라지면 달라진다")
+    func uiColorIdentifierReflectsAlphaDifferences() {
+        let opaqueBlue = UIColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 1.0)
+        let translucentBlue = UIColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 0.5)
+
+        #expect(opaqueBlue.id != translucentBlue.id)
+        #expect(opaqueBlue.id == UIColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 1.0).id)
+    }
+}


### PR DESCRIPTION
## 요약
- Domain 모듈에 `CodableColor` JSON 왕복 직렬화 테스트를 추가했습니다.
- `UIColor.id`가 RGBA 차이를 반영하는지 확인하는 Swift Testing을 추가했습니다.
- 기존 `BibleVerse` 파싱 테스트에 섞여 있던 잘못된 기대값과 `BibleChapterAndVerseTesting`의 문법 오류를 함께 정리했습니다.

## 선택한 모듈
- Domain

## 테스트한 동작
- `CodableColor`의 RGBA 값 JSON round-trip 보존
- `UIColor.id`의 RGBA 기반 식별자 안정성
- 기존 `BibleVerse` 파싱 테스트 기대값 정합성

## 변경 파일
- `Domain/Domain/Tests/CodableColorTesting.swift`
- `Domain/Domain/Tests/BibleVerseParsingTesting.swift`
- `Domain/Domain/Tests/BibleChapterAndVerseTesting.swift`

## 검증
- `xcodebuild test -workspace Carve.xcworkspace -scheme DomainTest -destination "platform=iOS Simulator,name=iPad Air 11-inch (M3)"`

## 남은 위험
- 테스트 스킴 전체에 SwiftLint 경고가 남아 있지만 이번 변경 범위 밖입니다.