### PR TITLE
ChartFeature 모델 Swift Testing 추가

### DIFF
--- a/Feature/ChartFeature/Tests/ChartModelTesting.swift
+++ b/Feature/ChartFeature/Tests/ChartModelTesting.swift
@@ -1,0 +1,50 @@
+//
+//  ChartModelTesting.swift
+//  ChartFeatureTests
+//
+//  Created by Codex on 5/20/26.
+//
+
+@testable import ChartFeature
+import Domain
+import Foundation
+import Testing
+
+struct ChartModelTesting {
+    @Test("최근 필사 항목은 성경 위치를 한글 표시 문자열로 만든다")
+    func recentVerseItemMessageUsesLocalizedBiblePosition() {
+        let item = RecentVerseItem(
+            verse: BibleVerse(
+                title: BibleChapter(title: .john, chapter: 3),
+                verse: 16,
+                sentence: "하나님이 세상을 이처럼 사랑하사"
+            ),
+            updatedAt: Date(timeIntervalSince1970: 1_800)
+        )
+
+        #expect(item.message == "요한복음 3장 16절")
+    }
+
+    @Test("최근 필사 항목 식별자는 성경 위치와 수정 시각으로 결정된다")
+    func recentVerseItemIDUsesBiblePositionAndUpdatedAt() {
+        let item = RecentVerseItem(
+            verse: BibleVerse(
+                title: BibleChapter(title: .psalms, chapter: 23),
+                verse: 1,
+                sentence: "여호와는 나의 목자시니"
+            ),
+            updatedAt: Date(timeIntervalSince1970: 2_400),
+            drawingID: "drawing-1"
+        )
+
+        #expect(item.id == "1-19Psalms.txt|23|1|2400.0")
+    }
+
+    @Test("일별 기록의 식별자는 날짜와 동일하다")
+    func dailyRecordIDMatchesDate() {
+        let date = Date(timeIntervalSince1970: 3_600)
+        let record = DailyRecord(date: date, count: 7)
+
+        #expect(record.id == date)
+    }
+}


### PR DESCRIPTION
## 요약
- ChartFeature 테스트 타깃에 Swift Testing 기반 모델 테스트를 추가했습니다.
- RecentVerseItem의 한글 표시 문자열과 식별자 생성 규칙을 검증했습니다.
- DailyRecord의 Identifiable id가 date와 동일한지 검증했습니다.

## 선택한 모듈
- ChartFeature

## 테스트한 동작
- RecentVerseItem.message가 성경 위치를 한글 문자열로 구성하는 동작
- RecentVerseItem.id가 책 파일명, 장, 절, 수정 시각으로 결정되는 동작
- DailyRecord.id가 date를 그대로 반환하는 동작

## 변경 파일
- Feature/ChartFeature/Tests/ChartModelTesting.swift

## 검증
- tuist generate
- xcodebuild test -workspace Carve.xcworkspace -scheme ChartFeatureTest -destination 'platform=iOS Simulator,OS=26.2,name=iPad Air 11-inch (M3)'

## 남은 위험 요소
- ChartFeature의 UI/리듀서 동작은 이번 범위에서 다루지 않았습니다.