### PR TITLE
[테스트] CarveToolkit 안전 서브스크립트 Swift Testing 추가

### DIFF
--- a/Supports/CarveToolkit/Tests/CollectionSafeSubscriptTesting.swift
+++ b/Supports/CarveToolkit/Tests/CollectionSafeSubscriptTesting.swift
@@ -1,0 +1,25 @@
+//
+//  CollectionSafeSubscriptTesting.swift
+//  CarveToolkitTest
+//
+//  Created by Codex on 5/21/26.
+//
+
+@testable import CarveToolkit
+import Testing
+
+struct CollectionSafeSubscriptTesting {
+    @Test("유효한 인덱스는 컬렉션 원소를 반환한다")
+    func returnsElementForValidIndex() {
+        let verses = ["창세기", "출애굽기", "레위기"]
+
+        #expect(verses[safe: verses.index(verses.startIndex, offsetBy: 1)] == "출애굽기")
+    }
+
+    @Test("끝 인덱스는 컬렉션 범위 밖이므로 nil을 반환한다")
+    func returnsNilForEndIndex() {
+        let verses = ["창세기", "출애굽기", "레위기"]
+
+        #expect(verses[safe: verses.endIndex] == nil)
+    }
+}


### PR DESCRIPTION
## 요약
- `CarveToolkit` 모듈의 `Collection` 안전 서브스크립트 동작을 Swift Testing으로 검증합니다.
- 유효한 인덱스 반환과 `endIndex` 범위 이탈 시 `nil` 반환을 테스트합니다.

## 선택한 모듈
- `CarveToolkit`

## 변경 파일
- `Supports/CarveToolkit/Tests/CollectionSafeSubscriptTesting.swift`

## 검증
- `tuist generate`
- `xcodebuild test -workspace Carve.xcworkspace -scheme CarveToolkitTest -destination 'platform=iOS Simulator,OS=26.2,name=iPad Air 11-inch (M3)'`

## 남은 위험
- 이번 변경은 `Collection` 안전 서브스크립트 경계 동작만 검증하며 다른 공용 확장 동작은 포함하지 않습니다.