### PR TITLE
UIComponents 확장 Swift Testing 추가

### DIFF
--- a/Supports/UIComponents/Tests/UIComponentsExtensionTesting.swift
+++ b/Supports/UIComponents/Tests/UIComponentsExtensionTesting.swift
@@ -1,0 +1,90 @@
+//
+//  UIComponentsExtensionTesting.swift
+//  UIComponentsTests
+//
+//  Created by Codex on 5/22/26.
+//
+
+import Foundation
+import Testing
+
+@testable import UIComponents
+
+struct UIComponentsExtensionTesting {
+    @Test("범위를 벗어난 비교 가능 값은 닫힌 범위 안으로 제한된다")
+    func comparableValueClampsToClosedRange() {
+        #expect((-1).clamped(to: 0...10) == 0)
+        #expect(4.clamped(to: 0...10) == 4)
+        #expect(12.clamped(to: 0...10) == 10)
+    }
+
+    @Test("달력 경계 계산은 날짜의 시간 구성요소를 제거한다")
+    func calendarStartsRemoveSmallerDateComponents() {
+        let calendar = makeCalendar()
+        let date = makeDate(calendar: calendar, year: 2026, month: 5, day: 22, hour: 13, minute: 47, second: 31)
+
+        #expect(calendar.startOfHour(for: date) == makeDate(
+            calendar: calendar,
+            year: 2026,
+            month: 5,
+            day: 22,
+            hour: 13
+        ))
+        #expect(calendar.startOfMonth(for: date) == makeDate(
+            calendar: calendar,
+            year: 2026,
+            month: 5,
+            day: 1
+        ))
+    }
+
+    @Test("달력 종료 경계 계산은 해당 기간의 마지막 초를 반환한다")
+    func calendarEndsUseLastSecondOfPeriod() {
+        let calendar = makeCalendar()
+        let date = makeDate(calendar: calendar, year: 2024, month: 2, day: 14, hour: 8)
+
+        #expect(calendar.endOfDay(for: date) == makeDate(
+            calendar: calendar,
+            year: 2024,
+            month: 2,
+            day: 14,
+            hour: 23,
+            minute: 59,
+            second: 59
+        ))
+        #expect(calendar.endOfMonth(for: date) == makeDate(
+            calendar: calendar,
+            year: 2024,
+            month: 2,
+            day: 29,
+            hour: 23,
+            minute: 59,
+            second: 59
+        ))
+    }
+
+    private func makeCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private func makeDate(
+        calendar: Calendar,
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int = 0,
+        minute: Int = 0,
+        second: Int = 0
+    ) -> Date {
+        calendar.date(from: DateComponents(
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute,
+            second: second
+        ))!
+    }
+}


### PR DESCRIPTION
## 요약
- `UIComponents` 모듈의 순수 확장 로직에 Swift Testing 테스트를 추가했습니다.
- `Comparable.clamped(to:)`의 범위 제한 동작과 `Calendar` 경계 계산을 검증합니다.

## 선택한 모듈
- `UIComponents`

## 테스트한 동작
- 닫힌 범위보다 작은 값, 범위 안 값, 큰 값의 clamp 결과
- 시간과 월 시작 경계가 하위 날짜 구성요소를 제거하는지
- 일 종료와 윤년 2월 월 종료가 해당 기간 마지막 초인지

## 변경 파일
- `Supports/UIComponents/Tests/UIComponentsExtensionTesting.swift`

## 검증
- `tuist generate`
- `xcodebuild test -workspace Carve.xcworkspace -scheme UIComponentsTest -destination 'platform=iOS Simulator,OS=26.2,name=iPad Air 11-inch (M3)'`

## 남은 위험
- 이번 변경은 `UIComponents` 확장 로직의 단위 테스트만 다루며 앱 통합 동작은 별도로 검증하지 않았습니다.