### PR TITLE
CarveFeature 헤더 상태 전이 Swift Testing 추가

### DIFF
--- a/Feature/CarveFeature/Tests/HeaderFeatureTesting.swift
+++ b/Feature/CarveFeature/Tests/HeaderFeatureTesting.swift
@@ -89,4 +89,34 @@ struct HeaderFeatureTesting {
         #expect(state.lastHeaderOffset == -72)
     }
 
+    @Test("헤더 높이를 전달받으면 상태에 그대로 반영한다")
+    func setHeaderHeightStoresMeasuredHeight() async {
+        var state = HeaderFeature.State.initialState
+
+        _ = HeaderFeature().reduce(into: &state, action: .view(.setHeaderHeight(64)))
+
+        #expect(state.headerHeight == 64)
+        #expect(state.headerOffset == 0)
+        #expect(state.lastHeaderOffset == 0)
+    }
+
+    @Test("연필 설정 버튼은 팔레트 표시 상태만 토글한다")
+    func pencilConfigTapTogglesPalatteVisibility() async {
+        var state = HeaderFeature.State.initialState
+        state.headerHeight = 72
+        state.headerOffset = -18
+
+        _ = HeaderFeature().reduce(into: &state, action: .view(.pencilConfigDidTapped))
+
+        #expect(state.showPalatte)
+        #expect(state.headerHeight == 72)
+        #expect(state.headerOffset == -18)
+
+        _ = HeaderFeature().reduce(into: &state, action: .view(.pencilConfigDidTapped))
+
+        #expect(!state.showPalatte)
+        #expect(state.headerHeight == 72)
+        #expect(state.headerOffset == -18)
+    }
+
 }


### PR DESCRIPTION
## 요약
- 선택 모듈: CarveFeature
- HeaderFeature의 헤더 높이 반영 동작을 Swift Testing으로 검증했습니다.
- HeaderFeature의 연필 설정 버튼 팔레트 표시 토글과 기존 헤더 위치 상태 보존을 검증했습니다.

## 변경 파일
- Feature/CarveFeature/Tests/HeaderFeatureTesting.swift

## 검증
- `$HOME/.local/share/mise/shims/swiftlint lint Feature/CarveFeature/Tests/HeaderFeatureTesting.swift --config .swiftlint.yml --no-cache`
- `xcodebuild test -workspace /Users/leetaek/Documents/Area/Carve/Carve/Carve.xcworkspace -scheme CarveFeatureTest -destination "platform=iOS Simulator,name=iPad Air 11-inch (M3)" -derivedDataPath /private/tmp/carve-deriveddata-carvefeature`

## 남은 위험 요소
- 범위는 HeaderFeature의 reducer 상태 전이에 한정했습니다. UI 렌더링이나 실제 스크롤 제스처 통합 동작은 다루지 않았습니다.