### PR TITLE
CarveFeature 헤더 상태 테스트 보강

### DIFF
--- a/Feature/CarveFeature/Tests/HeaderFeatureTesting.swift
+++ b/Feature/CarveFeature/Tests/HeaderFeatureTesting.swift
@@ -89,4 +89,27 @@ struct HeaderFeatureTesting {
         #expect(state.lastHeaderOffset == -72)
     }
 
+    @Test("헤더 높이를 전달받으면 상태에 그대로 반영한다")
+    func setHeaderHeightStoresMeasuredHeight() async {
+        var state = HeaderFeature.State.initialState
+
+        _ = HeaderFeature().reduce(into: &state, action: .view(.setHeaderHeight(88)))
+
+        #expect(state.headerHeight == 88)
+        #expect(state.headerOffset == 0)
+    }
+
+    @Test("연필 설정 버튼은 팔레트 표시 상태만 토글한다")
+    func pencilConfigDidTappedTogglesPalatteVisibility() async {
+        var state = HeaderFeature.State.initialState
+        state.headerHeight = 72
+        state.headerOffset = -24
+
+        _ = HeaderFeature().reduce(into: &state, action: .view(.pencilConfigDidTapped))
+
+        #expect(state.showPalatte)
+        #expect(state.headerHeight == 72)
+        #expect(state.headerOffset == -24)
+    }
+
 }


### PR DESCRIPTION
## 요약
- CarveFeature의 HeaderFeature 상태 전이 테스트를 확장했습니다.
- 헤더 높이 반영 액션과 연필 설정 버튼의 팔레트 표시 토글을 검증합니다.

## 선택한 모듈
- CarveFeature

## 테스트한 동작
- `setHeaderHeight` 액션이 측정된 헤더 높이를 상태에 저장하는지 확인
- `pencilConfigDidTapped` 액션이 팔레트 표시 상태만 토글하고 기존 헤더 위치 값은 유지하는지 확인

## 변경 파일
- `Feature/CarveFeature/Tests/HeaderFeatureTesting.swift`

## 검증
- `xcodebuild test -workspace Carve.xcworkspace -scheme CarveFeatureTest -destination "platform=iOS Simulator,name=iPad Pro 11-inch (M5),OS=26.2" -derivedDataPath /private/tmp/carve-derived-data-workspace CODE_SIGNING_ALLOWED=NO`

## 남은 위험 요소
- `Domain` 테스트 파일에는 이번 범위와 무관한 기존 테스트 이상 징후가 있어 건드리지 않았습니다. 이번 PR 검증 범위는 `CarveFeatureTest`로 제한했습니다.