### PR TITLE
SettingsFeature 문의 발송 검증 테스트 추가

### DIFF
--- a/Feature/SettingsFeature/Project.swift
+++ b/Feature/SettingsFeature/Project.swift
@@ -39,7 +39,7 @@ let target: [Target] = [
         dependencies: dependencies,
         settings: settings
     ),
-    .makeTestTarget(projName: projectName, target: .debug, script: script)
+    .makeTestTarget(projName: projectName, target: .debug, script: script, dependencies: [.target(name: projectName)])
 ]
 
 

--- a/Feature/SettingsFeature/Tests/SendFeedbackFeatureTesting.swift
+++ b/Feature/SettingsFeature/Tests/SendFeedbackFeatureTesting.swift
@@ -1,0 +1,49 @@
+//
+//  SendFeedbackFeatureTesting.swift
+//  SettingsFeatureTest
+//
+//  Created by Codex on 6/9/26.
+//
+
+@testable import SettingsFeature
+import Testing
+
+struct SendFeedbackFeatureTesting {
+    @Test("문의 제목이 비어 있으면 제목 입력 안내 메시지를 설정한다")
+    func sendButtonValidationRequiresTitle() {
+        var state = SendFeedbackFeature.State.initialState
+        state.feedbackInfo.body = "앱이 종료됩니다."
+        state.agreeToDefaultNotice = true
+        state.agreeToGetDeviceInfo = true
+
+        _ = SendFeedbackFeature().reduce(into: &state, action: .view(.isEnableSendButton))
+
+        #expect(state.popupMessage == "문의 제목을 입력해주세요.")
+    }
+
+    @Test("기본 문의 본문 템플릿에 내용이 없으면 본문 입력 안내 메시지를 설정한다")
+    func sendButtonValidationRequiresBodyAfterDefaultTemplate() {
+        var state = SendFeedbackFeature.State.initialState
+        state.feedbackInfo.title = "오류 제보"
+        state.feedbackInfo.body = "- 문의 내용:"
+        state.agreeToDefaultNotice = true
+        state.agreeToGetDeviceInfo = true
+
+        _ = SendFeedbackFeature().reduce(into: &state, action: .view(.isEnableSendButton))
+
+        #expect(state.popupMessage == "문의 내용을 입력해주세요.")
+    }
+
+    @Test("필수 동의가 하나라도 빠지면 동의 안내 메시지를 설정한다")
+    func sendButtonValidationRequiresAllAgreements() {
+        var state = SendFeedbackFeature.State.initialState
+        state.feedbackInfo.title = "개선 제안"
+        state.feedbackInfo.body = "- 문의 내용:필사 화면 여백 조정이 필요합니다."
+        state.agreeToDefaultNotice = true
+        state.agreeToGetDeviceInfo = false
+
+        _ = SendFeedbackFeature().reduce(into: &state, action: .view(.isEnableSendButton))
+
+        #expect(state.popupMessage == "필수 동의 항목을 체크해주세요.")
+    }
+}


### PR DESCRIPTION
## 요약
- SettingsFeature 모듈의 SendFeedbackFeature 발송 가능 여부 검증 분기를 Swift Testing으로 보강했습니다.
- 비어 있는 SettingsFeatureTest 타깃이 본 모듈을 import할 수 있도록 테스트 타깃 의존성을 기존 모듈 패턴에 맞췄습니다.

## 선택한 모듈
- SettingsFeature

## 테스트한 동작
- 문의 제목이 비어 있을 때 제목 입력 안내 메시지를 설정합니다.
- 기본 문의 본문 템플릿에 실제 내용이 없을 때 본문 입력 안내 메시지를 설정합니다.
- 필수 동의 항목 중 하나라도 빠졌을 때 동의 안내 메시지를 설정합니다.

## 변경 파일
- Feature/SettingsFeature/Project.swift
- Feature/SettingsFeature/Tests/SendFeedbackFeatureTesting.swift

## 검증
- tuist generate
- xcodebuild test -workspace Carve.xcworkspace -scheme SettingsFeatureTest -destination "platform=iOS Simulator,name=iPad Pro 11-inch (M5),OS=26.2" -derivedDataPath /private/tmp/carve-derived-data-settingsfeature CODE_SIGNING_ALLOWED=NO

## 남은 위험 요소
- 검증 로그에 기존 SwiftLint 경고가 출력됐지만, 이번 변경 파일의 실패 요인은 아니며 테스트는 통과했습니다.
- 메일 전송 가능 여부나 PhotosUI 로딩 같은 외부 I/O 분기는 이번 범위에서 다루지 않았습니다.