### PR TITLE
CarveToolkit 날짜 확장 테스트 추가

### DIFF
--- a/Supports/CarveToolkit/Project.swift
+++ b/Supports/CarveToolkit/Project.swift
@@ -25,7 +25,7 @@ let settings: Settings = .settings(
 
 let target: [Target] = [
     .makeFrameworkTarget(projName: projectName, target: .debug, script: script, dependencies: dependencies),
-    .makeTestTarget(projName: projectName, target: .debug, script: script)
+    .makeTestTarget(projName: projectName, target: .debug, script: script, dependencies: [.target(name: projectName)])
 ]
 
 let project = Project.makeModule(

--- a/Supports/CarveToolkit/Tests/DateExtensionTesting.swift
+++ b/Supports/CarveToolkit/Tests/DateExtensionTesting.swift
@@ -1,0 +1,65 @@
+//
+//  DateExtensionTesting.swift
+//  CarveToolkitTest
+//
+//  Created by Codex on 6/11/26.
+//
+
+@testable import CarveToolkit
+import Foundation
+import Testing
+
+struct DateExtensionTesting {
+    @Test("날짜 정렬은 같은 날의 시간을 자정으로 내린다")
+    func alignToDayDropsTimeComponents() throws {
+        let date = try #require(makeDate(year: 2026, month: 6, day: 11, hour: 18, minute: 42, second: 9))
+        let aligned = date.alignToDay()
+
+        #expect(aligned == makeDate(year: 2026, month: 6, day: 11))
+    }
+
+    @Test("일 단위 더하기는 월 경계를 넘어도 날짜를 유지한다")
+    func addDaysCrossesMonthBoundary() throws {
+        let date = try #require(makeDate(year: 2026, month: 1, day: 30, hour: 9))
+
+        #expect(date.addDays(2) == makeDate(year: 2026, month: 2, day: 1, hour: 9))
+        #expect(date.addDays(-30) == makeDate(year: 2025, month: 12, day: 31, hour: 9))
+    }
+
+    @Test("시간 단위 더하기는 일 경계를 넘어도 분과 초를 유지한다")
+    func addHoursCrossesDayBoundary() throws {
+        let date = try #require(makeDate(year: 2026, month: 6, day: 11, hour: 23, minute: 15, second: 30))
+
+        #expect(date.addHours(2) == makeDate(year: 2026, month: 6, day: 12, hour: 1, minute: 15, second: 30))
+        #expect(date.addHours(-24) == makeDate(year: 2026, month: 6, day: 10, hour: 23, minute: 15, second: 30))
+    }
+
+    @Test("정오 계산은 입력 시간과 무관하게 같은 날 12시를 반환한다")
+    func middleOfDayReturnsNoonOfSameDay() throws {
+        let date = try #require(makeDate(year: 2026, month: 6, day: 11, hour: 23, minute: 59, second: 59))
+
+        #expect(date.middleOfDay() == makeDate(year: 2026, month: 6, day: 11, hour: 12))
+    }
+}
+
+private func makeDate(
+    year: Int,
+    month: Int,
+    day: Int,
+    hour: Int = 0,
+    minute: Int = 0,
+    second: Int = 0
+) -> Date? {
+    let calendar = Calendar.current
+
+    return calendar.date(
+        from: DateComponents(
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute,
+            second: second
+        )
+    )
+}


### PR DESCRIPTION
## 요약
- `CarveToolkit` 모듈의 `Date` 확장 로직을 Swift Testing으로 검증합니다.
- 날짜 정렬, 일/시간 단위 이동, 정오 계산처럼 차트/기간 계산에서 재사용되는 결정적 동작을 다룹니다.
- 테스트 타깃에서 본 모듈을 `@testable import`할 수 있도록 `CarveToolkitTest` 의존성을 보강했습니다.

## 선택한 모듈
- `CarveToolkit`

## 테스트한 동작
- `alignToDay()`가 같은 날의 시간을 자정으로 내리는 동작
- `addDays(_:)`가 월/연 경계를 넘어 날짜를 계산하는 동작
- `addHours(_:)`가 일 경계를 넘어도 분과 초를 유지하는 동작
- `middleOfDay()`가 입력 시간과 무관하게 같은 날 정오를 반환하는 동작

## 변경 파일
- `Supports/CarveToolkit/Tests/DateExtensionTesting.swift`
- `Supports/CarveToolkit/Project.swift`

## 검증 단계
- `tuist generate`
- `xcodebuild test -workspace Carve.xcworkspace -scheme CarveToolkitTest -destination "platform=iOS Simulator,name=iPad Pro 11-inch (M5),OS=26.2" -derivedDataPath /private/tmp/carve-derived-data-carvetoolkit-date CODE_SIGNING_ALLOWED=NO`

## 남은 위험 요소
- 이번 변경은 `Date` 확장의 단위 동작만 검증하며, 실제 차트 화면의 통합 흐름은 별도 범위입니다.
- 같은 모듈의 열린 PR #21과 테스트 파일은 겹치지 않지만, 둘 다 `CarveToolkitTest`를 다루므로 병합 순서에 따라 재생성이 필요할 수 있습니다.
